### PR TITLE
#77 Remove the Definition of #kit-wallpaper

### DIFF
--- a/system/kitstrap/kitstrap.css
+++ b/system/kitstrap/kitstrap.css
@@ -97,16 +97,6 @@ kit-navbar-alt .kit-navitem:hover,
     text-decoration: underline;
 }
 
-#kit-wallpaper {
-    position: fixed;
-    top: 0px;
-    left: 0px;
-    height: 100%;
-    width: 100%;
-    background: url("");
-    background-size: cover;
-}
-
 .kit-d-icon {
     border-radius: 5px;
     padding: 4px;


### PR DESCRIPTION
## Outline
- "#kit-wallpaper" Style of system.css was conflicting with kitstrap.

> Default wallpaper will not displayed due to definition of kitstrap.
>
> #77 

- Remove the definition of kit-wallpaper id from kitstrap file

close #77