### PR TITLE
#84 Fix the screen time recording system

### DIFF
--- a/system.js
+++ b/system.js
@@ -1189,7 +1189,6 @@ const KWS = new function(){
                 localStorage.setItem('kit-screentime', JSON.stringify(KWS.screenTime));
             }
             else{
-                console.log(_pid + '外れました');
                 $("#"+array[i].id).removeClass("windowactive");
                 $("#t"+_pid).removeClass("t-active");
                 process[_pid].isactive = false;
@@ -1197,7 +1196,8 @@ const KWS = new function(){
                     let _diff = (new Date() - KWS.screenPrevSwitched);
                     let _appid = process[_pid].id
                     if( !KWS.screenTime[_appid] ) KWS.screenTime[_appid] = new Number();
-                    KWS.screenTime[_appid] += _diff;
+                    if( _diff < 0 ) Notification.push('debug', 'スクリーンタイムの記録に失敗しました。', 'system')
+                    else KWS.screenTime[_appid] += _diff;
                 }
             }
         }


### PR DESCRIPTION
## Outline

- Add validation of the time an app was displayed on.

Fixed this Issue(#84): 

> Screen time system may record negative number as the time an app was displayed.
> You may be able to see this if you change time zone setting between switching displayed apps.

close #84